### PR TITLE
Allow closure type for predefined_data

### DIFF
--- a/Form/ChoosePaymentMethodType.php
+++ b/Form/ChoosePaymentMethodType.php
@@ -170,7 +170,7 @@ class ChoosePaymentMethodType extends AbstractType
             'allowed_methods' => 'array',
             'amount'          => array('numeric', 'closure'),
             'currency'        => 'string',
-            'predefined_data' => 'array',
+            'predefined_data' => array('array', 'closure'),
         ));
     }
 


### PR DESCRIPTION
ChoosePaymentMethodType explicitly allows `closure` as allowed type for option `predefined_data`
=> sf 2.6 compatibility
